### PR TITLE
Replace subfigure with subfig

### DIFF
--- a/ics5110_ml_handbook.tex
+++ b/ics5110_ml_handbook.tex
@@ -9,6 +9,10 @@
 \publisher{Publisher of This Book}
 
 %%
+% Splits figures into subfigures
+\usepackage{subfig}
+
+%%
 % If they're installed, use Bergamo and Chantilly from www.fontsite.com.
 % They're clones of Bembo and Gill Sans, respectively.
 %\IfFileExists{bergamo.sty}{\usepackage[osf]{bergamo}}{}% Bembo

--- a/terms/crossvalidation_lmd.tex
+++ b/terms/crossvalidation_lmd.tex
@@ -16,16 +16,16 @@ This method is a specific case of the LpO method having $p=1$. It requires less 
 
 \begin{figure*}
 \centering
-\begin{subfigure}
+\begin{subfloat}
   \centering
   \includegraphics[width=.4\linewidth]{leavep.png}
   \caption{Leave-p-Out}
-  \end{subfigure}
- \begin{subfigure}
+  \end{subfloat}
+ \begin{subfloat}
   \centering
   \includegraphics[width=.37\linewidth]{leave1.png}
   \caption{Leave-One-Out}
-  \end{subfigure}
+  \end{subfloat}
   \caption{Exhaustive cross-validation methods: Leave-p-Out (left) \& Leave-One-Out (right)}
   \label{fig:leavep}
 \end{figure*}
@@ -59,18 +59,18 @@ Underfitting \index{underfitting} is when the model has a low degree (e.g. $y = 
 
 \begin{figure*}
 \centering
-\begin{subfigure}
+\begin{subfloat}
   \centering
   \includegraphics[width=0.4\linewidth]{underfitting.png}
   \caption{Underfitting}
   \label{fig:underfitting}
-\end{subfigure}
-\begin{subfigure}
+\end{subfloat}
+\begin{subfloat}
   \centering
   \includegraphics[width=.4\linewidth]{overfitting.png}
   \caption{Overfitting}
   \label{fig:overfitting}
-\end{subfigure}
+\end{subfloat}
 \caption{Underfitting (left) \& Overfitting (right)}
 \label{fig:models}
 \end{figure*}


### PR DESCRIPTION
Subfigure isn't included but referenced in the cross-validation terms.
Once included, it doesn't work well. For example, figure references
remain empty. Since this package is deprecated I replaced it with
subfig (refer to https://ctan.org/pkg/subfigure?lang=en).